### PR TITLE
Ensure bitmap objects are not null before calling .recycle() on them.…

### DIFF
--- a/faimsandroidapp/src/main/java/au/org/intersect/faims/android/managers/BitmapManager.java
+++ b/faimsandroidapp/src/main/java/au/org/intersect/faims/android/managers/BitmapManager.java
@@ -30,7 +30,9 @@ public class BitmapManager {
 	public synchronized void destroy() {
 		if (bitmaps != null) {
 			for (Bitmap bitmap : bitmaps) {
-				bitmap.recycle();
+				if (null != bitmap) {
+					bitmap.recycle();
+				}
 			}
 			this.bitmaps = null;
 		}


### PR DESCRIPTION
…  Fixes crash on exit for some modules
